### PR TITLE
Update build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,6 @@
 ./gradlew app-compose-ui-devices:build
 cd app-compose-ui-devices/build/outputs/aar
 unzip app-compose-ui-devices-release.aar
-~/Library/Android/sdk/build-tools/30.0.3/dx --dex --min-sdk-version=26 --output=compose_ui_devices.dex classes.jar
-cp compose_ui_devices.dex ../../../../app/src/main/assets
-./gradlew assembleDebug
+~/Library/Android/sdk/build-tools/30.0.3/d8 classes.jar
+cp classes.dex ../../../../app/src/main/assets/compose_ui_devices.dex
+./gradlew installDebug


### PR DESCRIPTION
修复aar中classes.jar转化为dex时未脱糖导致的crash